### PR TITLE
[BUG-591] fix default centering

### DIFF
--- a/addon/components/date-picker.js
+++ b/addon/components/date-picker.js
@@ -33,6 +33,14 @@ export default Component.extend({
     'December',
   ],
 
+  center: computed('max', function() {
+    let max = this.get('max');
+
+    if (!moment().isBefore(moment(max))) {
+      return max;
+    }
+  }),
+
   maximum: computed('max', function() {
     let defaultValue = moment().add(1, 'year').startOf('day').toDate();
     let val = this.get('max') || defaultValue;

--- a/addon/templates/components/date-picker.hbs
+++ b/addon/templates/components/date-picker.hbs
@@ -15,6 +15,7 @@
     selected=value
     onSelect=(action 'setValueAndValidate' value='date')
     disabled=isDisabled
+    center=center
     as |dp|}}
     {{#dp.trigger
       tabindex='-1'

--- a/tests/integration/components/date-picker-desktop-test.js
+++ b/tests/integration/components/date-picker-desktop-test.js
@@ -173,3 +173,47 @@ test('year drop down works', async function(assert) {
     'correct year should be set'
   );
 });
+
+test('correctly initializes center value', async function(assert) {
+  let maximum = new Date('2030-01-01');
+  this.set('maximum', maximum);
+
+  this.render(hbs`{{date-picker
+    maximum=maximum
+    isMobile=false
+  }}`);
+
+  await click('[data-test-selector="date-picker-trigger"]');
+
+  let calendarNav = find('[data-test-selector="calendar-nav"]');
+  let centerDateString = calendarNav.getAttribute('data-test-center-value');
+  let centerDate = moment(centerDateString);
+
+  assert.equal(
+    centerDate.get('year'),
+    moment().year(),
+    'correct year should be set'
+  );
+});
+
+test('initializes center value to maximum if max is in the past', async function(assert) {
+  let maximum = new Date('2010-12-31');
+  this.set('maximum', maximum);
+
+  this.render(hbs`{{date-picker
+    max=maximum
+    isMobile=false
+  }}`);
+
+  await click('[data-test-selector="date-picker-trigger"]');
+
+  let calendarNav = find('[data-test-selector="calendar-nav"]');
+  let centerDateString = calendarNav.getAttribute('data-test-center-value');
+  let centerDate = moment(centerDateString);
+
+  assert.equal(
+    centerDate.get('year'),
+    2010,
+    'correct year should be set'
+  );
+});


### PR DESCRIPTION
when max value is in the past the default ember-power-calendar doesn't
work because it defaults to "today" hence giving disabled dates.

this commit sets a sane default by using max instead of today when
needed


@jherdman, after reproducing it in a twiddle and assuming that my solution is correct I'm not convinced that this is a bug in ember-power-calendar anymore

I'd like to attempt a release of this patch, updating ES and testing if it fixes
  

https://ember-twiddle.com/8b331fb2a0d368a18b74c2d8ed8b08c3