### PR TITLE
Attribute passthrough RE: SP-128

### DIFF
--- a/addon/templates/components/date-picker.hbs
+++ b/addon/templates/components/date-picker.hbs
@@ -9,6 +9,7 @@
    class={{inputClass}}
    min={{moment-format minimum 'YYYY-MM-DD' timeZone='UTC'}}
    max={{moment-format maximum 'YYYY-MM-DD' timeZone='UTC'}}
+   required={{required}}
    data-test-selector="input-field">
 {{else}}
   {{#power-datepicker
@@ -16,6 +17,7 @@
     onSelect=(action 'setValueAndValidate' value='date')
     disabled=isDisabled
     center=center
+    verticalPosition=verticalPosition
     as |dp|}}
     {{#dp.trigger
       tabindex='-1'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@precision-nutrition/date-picker",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Pass through the `required` attribute to the input field (needed for styling, though it could come in handy for more obvious cases) as well as `verticalPosition` to `{{ember-basic-dropdown` since that component's position calc code is [fucking terrifying](https://github.com/cibernox/ember-basic-dropdown/blob/850c227c0a58148056d55d41aa0e5d88656b8165/addon/utils/calculate-position.js#L28) and we [can't trust it](https://user-images.githubusercontent.com/17125387/43664092-394eea8a-9731-11e8-849b-1cc23c156baa.png).

Included version bump for convenience, I'll publish to NPM after merge.