### PR TITLE
[SP-319] Allow datepicker center to be explicitly set

### DIFF
--- a/addon/components/date-picker.js
+++ b/addon/components/date-picker.js
@@ -81,6 +81,23 @@ export default Component.extend({
     return selectableYears.reverse();
   }),
 
+  init() {
+    this._super(...arguments);
+
+    let explicitCenter = this.get('explicitCenter');
+    let value = this.get('value');
+
+    if (!explicitCenter) {
+      return;
+    }
+
+    if (explicitCenter && value) {
+      this.set('center', value);
+    } else {
+      this.set('center', explicitCenter);
+    }
+  },
+
   datePicker: service(),
 
   isNativePickerDisplayed: readOnly('datePicker.isNativePickerDisplayed'),

--- a/tests/integration/components/date-picker-test.js
+++ b/tests/integration/components/date-picker-test.js
@@ -215,6 +215,28 @@ module('Integration | Component | date picker', function(hooks) {
       );
     });
 
+    test('correctly initializes center value when explicitly set', async function(assert) {
+      let dateInThePast = '1979-06-01';
+      let explicitCenter = new Date(dateInThePast);
+      this.set('explicitCenter', explicitCenter);
+
+      await render(hbs`{{date-picker
+        explicitCenter=explicitCenter
+      }}`);
+
+      await click('[data-test-selector="date-picker-trigger"]');
+
+      let calendarNav = find('[data-test-selector="calendar-nav"]');
+      let centerDateString = calendarNav.getAttribute('data-test-center-value');
+      let centerDate = moment(centerDateString);
+
+      assert.equal(
+        centerDate.get('year'),
+        1979,
+        'correct year should be set'
+      );
+    });
+
     test('can disable the trigger field', async function(assert) {
       await render(hbs`{{date-picker
         max=maximum


### PR DESCRIPTION
The value we pass to `center` is a CP, but we should also allow for this attribute to be explicitly set.

See SP-319: https://precisionnutrition.atlassian.net/browse/SP-319