### PR TITLE
[SP-589] Switch date I/O to YYYY-MM-DD

### DIFF
--- a/addon/components/date-picker.js
+++ b/addon/components/date-picker.js
@@ -31,6 +31,20 @@ export default Component.extend({
 
   selectableMonthOptions,
 
+  castedValue: computed('value', function() {
+    let value = this.get('value');
+
+    if (!value) {
+      return null;
+    }
+
+    let isNativePickerDisplayed = this.get('isNativePickerDisplayed');
+    let casted = moment(value, 'YYYY-MM-DD');
+
+    // Native input wants YYYY-MM-DD, desktop fancy picker wants a date object
+    return isNativePickerDisplayed ? casted.format('YYYY-MM-DD') : casted.toDate();
+  }),
+
   center: computed('max', function() {
     let max = this.get('max');
 
@@ -116,7 +130,7 @@ export default Component.extend({
 
       // pickadate doesn't know anything about time zones
       // https://github.com/amsul/pickadate.js/issues/875
-      let date = this.get('isNativePickerDisplayed') ? moment(newDate).toDate() : newDate;
+      let date = moment(newDate).format('YYYY-MM-DD');
 
       // TODO Remove this once we're using fullscreen-card-renderer everywhere
       let onChange = this.get('on-change');

--- a/addon/templates/components/date-picker.hbs
+++ b/addon/templates/components/date-picker.hbs
@@ -1,7 +1,7 @@
 {{#if isNativePickerDisplayed}}
   <input
     type="date"
-    value={{moment-format value "YYYY-MM-DD"}}
+    value={{castedValue}}
     name={{name}}
     disabled={{isDisabled}}
     placeholder={{placeholder}}
@@ -14,7 +14,7 @@
   >
 {{else}}
   {{#power-datepicker
-    selected=value
+    selected=castedValue
     onSelect=(action "setValueAndValidate" value="date")
     disabled=isDisabled
     center=center

--- a/tests/acceptance/pick-a-date-test.js
+++ b/tests/acceptance/pick-a-date-test.js
@@ -6,7 +6,7 @@ module('Acceptance | pick a date', function(hooks) {
   setupApplicationTest(hooks);
 
   test('sanity check pick a date', async function(assert) {
-    let expectedValue = new Date(2015, 0, 2);
+    let expectedValue = '2015-01-02';
 
     await visit('/');
 

--- a/tests/integration/components/date-picker-test.js
+++ b/tests/integration/components/date-picker-test.js
@@ -15,8 +15,50 @@ module('Integration | Component | date picker', function(hooks) {
     });
 
     test('sets value on input field', async function(assert) {
-      let testDate = new Date();
+      let testDate = moment().format('YYYY-MM-DD');
+
       this.set('testDate', testDate);
+
+      await render(hbs`{{date-picker
+        value=testDate
+      }}`);
+
+      let elem = find('input');
+
+      let dateString = moment(testDate).format('MMMM D, YYYY');
+
+      assert.equal(
+        elem.value,
+        dateString,
+        'sets value correctly on picker'
+      );
+    });
+
+    test('supports legacy date object value', async function(assert) {
+      let testDate = new Date();
+
+      this.set('testDate', testDate);
+
+      await render(hbs`{{date-picker
+        value=testDate
+      }}`);
+
+      let elem = find('input');
+
+      let dateString = moment(testDate).format('MMMM D, YYYY');
+
+      assert.equal(
+        elem.value,
+        dateString,
+        'sets value correctly on picker'
+      );
+    });
+
+    test('supports legacy localstorage value', async function(assert) {
+      let testDate = new Date();
+      let testDateInIsoFormat = testDate.toISOString();
+
+      this.set('testDate', testDateInIsoFormat);
 
       await render(hbs`{{date-picker
         value=testDate
@@ -339,8 +381,47 @@ module('Integration | Component | date picker', function(hooks) {
     });
 
     test('sets value on input field', async function(assert) {
+      let initialDate = '2016-10-01';
+      let newDate = '2018-01-18';
+
+      this.set('testDate', initialDate);
+
+      await render(hbs`{{date-picker
+        value=testDate
+      }}`);
+
+      let currentValue = find('input').value;
+
+      assert.equal(
+        currentValue,
+        moment(initialDate).format('YYYY-MM-DD'),
+        'hydrates the value correctly'
+      );
+
+      let elem = find('input');
+
+      await fillIn(elem, newDate);
+
+      let expectedDateValue = moment(newDate, 'YYYY-MM-DD')
+        .startOf('day')
+        .utcOffset(0)
+        .toDate();
+
+      assert.equal(
+        elem.value,
+        newDate,
+        'sets date correctly on mobile picker input field'
+      );
+
+      assert.deepEqual(
+        this.get('testDate'),
+        expectedDateValue,
+        'sets value correctly'
+      );
+    });
+
+    test('supports legacy date object value', async function(assert) {
       let testDate = new Date();
-      let requestedDate = '2016-10-01';
 
       this.set('testDate', testDate);
 
@@ -355,26 +436,24 @@ module('Integration | Component | date picker', function(hooks) {
         moment(testDate).format('YYYY-MM-DD'),
         'hydrates the value correctly'
       );
+    });
 
-      let elem = find('input');
+    test('supports legacy localstorage value', async function(assert) {
+      let testDate = new Date();
+      let testDateInIsoFormat = testDate.toISOString();
 
-      await fillIn(elem, requestedDate);
+      this.set('testDate', testDateInIsoFormat);
 
-      let expectedDateValue = moment(requestedDate, 'YYYY-MM-DD')
-        .startOf('day')
-        .utcOffset(0)
-        .toDate();
+      await render(hbs`{{date-picker
+        value=testDate
+      }}`);
+
+      let currentValue = find('input').value;
 
       assert.equal(
-        elem.value,
-        requestedDate,
-        'sets date correctly on mobile picker input field'
-      );
-
-      assert.deepEqual(
-        this.get('testDate'),
-        expectedDateValue,
-        'sets value correctly'
+        currentValue,
+        moment(testDate).format('YYYY-MM-DD'),
+        'hydrates the value correctly'
       );
     });
 
@@ -398,14 +477,12 @@ module('Integration | Component | date picker', function(hooks) {
       let testDate = new Date();
       let requestedDate = '2016-10-01';
 
-      let expectedDateValue = moment(requestedDate, 'YYYY-MM-DD').startOf('day').utcOffset(0).toDate();
-
       this.set('testDate', testDate);
 
       this.set('onChange', (value) => {
         assert.deepEqual(
           value,
-          expectedDateValue,
+          requestedDate,
           'passes new value to handler'
         );
       });


### PR DESCRIPTION
Finally, the timezone problem goes away forever. Birthdates are stored as strings, not dates. New `castedValue` CP determines what it should send out to the control. And Fitpros will no longer see "Invalid date" in the FCR when viewing an intake.

Bonus: when this reaches the apps, existing localstorage values (say, on a half-filled intake) will correctly render on the picker.

So will old database values.

Everyone wins.